### PR TITLE
Fix RL training environment

### DIFF
--- a/dqn_agent.py
+++ b/dqn_agent.py
@@ -76,7 +76,7 @@ class DQNAgent:
 
     def update(self):
         if len(self.replay_buffer) < self.batch_size:
-            return
+            return None
         states, actions, rewards, next_states, dones = self.replay_buffer.sample(self.batch_size)
         states = torch.FloatTensor(states).to(self.device)
         actions = torch.LongTensor(actions).unsqueeze(1).to(self.device)
@@ -96,6 +96,8 @@ class DQNAgent:
 
         if self.total_steps % self.target_sync == 0:
             self.target_net.load_state_dict(self.q_net.state_dict())
+
+        return loss.item()
 
     def step(self):
         self.total_steps += 1

--- a/dqn_agent.py
+++ b/dqn_agent.py
@@ -62,6 +62,7 @@ class DQNAgent:
         self.total_steps = 0
         self.target_sync = 1000
         self.action_dim = action_dim
+        self.update_epsilon()
 
     def select_action(self, state, eval=False):
         if (not eval) and random.random() < self.epsilon:
@@ -99,7 +100,10 @@ class DQNAgent:
 
         return loss.item()
 
+    def update_epsilon(self):
+        decay_ratio = min(1.0, self.total_steps / self.epsilon_decay_steps)
+        self.epsilon = self.epsilon_start - (self.epsilon_start - self.epsilon_end) * decay_ratio
+
     def step(self):
         self.total_steps += 1
-        decay_rate = max(0, (self.epsilon_decay_steps - self.total_steps) / self.epsilon_decay_steps)
-        self.epsilon = self.epsilon_end + (self.epsilon_start - self.epsilon_end) * decay_rate
+        self.update_epsilon()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ numpy
 torch
 colorama
 Pillow
+tqdm
+matplotlib
+tensorboard

--- a/scripts/evaluate_moves.py
+++ b/scripts/evaluate_moves.py
@@ -35,7 +35,7 @@ def evaluate_moves(game_state):
                     # Update Game State
                     move_card_to_foundation_from_waste(game_state, top_waste_card)
                     utils.capture_window("BlueStacks App Player")
-                    cards = utils.detect_suit_and_rank("C:\_\solitaire_bot\game_screenshot.bmp")
+                    cards = utils.detect_suit_and_rank(r"C:\_\solitaire_bot\game_screenshot.bmp")
                     game_state = utils.parse_game_state(game_state, cards)
                     print_moves([performed_moves[-1]])
 
@@ -63,7 +63,7 @@ def evaluate_moves(game_state):
                     # Update Game State
                     move_card_to_column_from_waste(game_state, to_column)
                     utils.capture_window("BlueStacks App Player")
-                    cards = utils.detect_suit_and_rank("C:\_\solitaire_bot\game_screenshot.bmp")
+                    cards = utils.detect_suit_and_rank(r"C:\_\solitaire_bot\game_screenshot.bmp")
                     game_state = utils.parse_game_state(game_state, cards)
                     print_moves([performed_moves[-1]])
 
@@ -98,7 +98,7 @@ def evaluate_moves(game_state):
             # Update Game State
             move_card_to_foundation_from_column(game_state, best_move["from_column"], best_move["card"])
             utils.capture_window("BlueStacks App Player")
-            cards = utils.detect_suit_and_rank("C:\_\solitaire_bot\game_screenshot.bmp")
+            cards = utils.detect_suit_and_rank(r"C:\_\solitaire_bot\game_screenshot.bmp")
             game_state = utils.parse_game_state(game_state, cards)
             performed_moves.append(best_move)
             print_moves([performed_moves[-1]])
@@ -142,7 +142,7 @@ def evaluate_moves(game_state):
             automate_moves.perform_move(move)
             move_card_to_column_from_column(game_state, best_move["from_column"], best_move["card"])
             utils.capture_window("BlueStacks App Player")
-            cards = utils.detect_suit_and_rank("C:\_\solitaire_bot\game_screenshot.bmp")
+            cards = utils.detect_suit_and_rank(r"C:\_\solitaire_bot\game_screenshot.bmp")
             game_state = utils.parse_game_state(game_state, cards)
             performed_moves.append(best_move)
             print_moves([performed_moves[-1]])
@@ -186,7 +186,7 @@ def evaluate_moves(game_state):
             automate_moves.perform_move(move)
             move_card_to_column_from_column(game_state, best_move["from_column"], best_move["card"])
             utils.capture_window("BlueStacks App Player")
-            cards = utils.detect_suit_and_rank("C:\_\solitaire_bot\game_screenshot.bmp")
+            cards = utils.detect_suit_and_rank(r"C:\_\solitaire_bot\game_screenshot.bmp")
             game_state = utils.parse_game_state(game_state, cards)
             performed_moves.append(best_move)
             print_moves([performed_moves[-1]])
@@ -219,7 +219,7 @@ def evaluate_moves(game_state):
                 # Update Game State
                 move_card_to_foundation_from_waste(game_state, top_waste_card)
                 utils.capture_window("BlueStacks App Player")
-                cards = utils.detect_suit_and_rank("C:\_\solitaire_bot\game_screenshot.bmp")
+                cards = utils.detect_suit_and_rank(r"C:\_\solitaire_bot\game_screenshot.bmp")
                 game_state = utils.parse_game_state(game_state, cards)
                 print_moves([performed_moves[-1]])
 
@@ -247,7 +247,7 @@ def evaluate_moves(game_state):
                 # Update Game State
                 move_card_to_column_from_waste(game_state, to_column)
                 utils.capture_window("BlueStacks App Player")
-                cards = utils.detect_suit_and_rank("C:\_\solitaire_bot\game_screenshot.bmp")
+                cards = utils.detect_suit_and_rank(r"C:\_\solitaire_bot\game_screenshot.bmp")
                 game_state = utils.parse_game_state(game_state, cards)
                 print_moves([performed_moves[-1]])
 

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -131,7 +131,9 @@ def detect_suit_and_rank(image_path, suit_threshold=0.9, rank_threshold=0.95):
 
     for suit in detected_suits:
         # Step 2: Detect Rank of cards
-        rank_templates_dir = f"{RANK_TEMPLATES_DIR}\{suit['name']}s"
+        # Build the path to the rank templates directory using os.path.join to
+        # avoid platform specific escaping issues.
+        rank_templates_dir = os.path.join(RANK_TEMPLATES_DIR, f"{suit['name']}s")
         best_match_score = 0
         best_result = []
 

--- a/solitaire_env.py
+++ b/solitaire_env.py
@@ -3,7 +3,23 @@ import gym
 from gym import spaces
 
 from scripts import game_setup
-from scripts.evaluate_moves import is_valid_column_move
+# `is_valid_column_move` from `scripts.evaluate_moves` is reproduced here to
+# avoid importing the entire module (which requires GUI dependencies).
+def is_valid_column_move(card, target_card):
+    """Return True if ``card`` can be placed onto ``target_card`` in a column."""
+    card_rank, card_suit = card[:-1], card[-1]
+    target_rank, target_suit = target_card[:-1], target_card[-1]
+    if not card_rank:
+        return False
+
+    red_suits = {"H", "D"}
+    black_suits = {"C", "S"}
+    if (card_suit in red_suits and target_suit in red_suits) or \
+       (card_suit in black_suits and target_suit in black_suits):
+        return False
+
+    rank_order = "A23456789TJQK"
+    return rank_order.index(card_rank) + 1 == rank_order.index(target_rank)
 
 # Simple Klondike environment using 3-card waste cycles.
 # Tableau columns contain full card names, with hidden cards
@@ -32,7 +48,10 @@ class KlondikeEnv(gym.Env):
         pile = self.state['foundations'][suit]
         if not pile:
             return card[0] == 'A'
-        return RANK_ORDER.index(card[0]) == RANK_ORDER.index(pile[-1]) + 1
+        # Compare only the rank characters. ``pile[-1]`` stores full card names
+        # such as "5H", so we slice the rank before looking it up in
+        # ``RANK_ORDER``.
+        return RANK_ORDER.index(card[0]) == RANK_ORDER.index(pile[-1][0]) + 1
 
     def _can_move_to_column(self, card, column):
         if not column:

--- a/solitaire_env.py
+++ b/solitaire_env.py
@@ -154,13 +154,27 @@ class KlondikeEnv(gym.Env):
         return self._get_obs(), {}
 
     def step(self, action):
+        shaped_reward = 0
         moves = self._legal_moves()
         if action < len(moves):
-            self._apply_move(moves[action])
+            move = moves[action]
+            pre_face_down = list(self.face_down_counts)
+            if move[0] in ("t2f", "w2f"):
+                shaped_reward += 100
+            if move[0] in ("w2t", "w2f"):
+                shaped_reward += 20
+            self._apply_move(move)
+            if move[0] in ("t2f", "t2t"):
+                col = move[1]
+                if pre_face_down[col] > self.face_down_counts[col]:
+                    shaped_reward += 20
         else:
+            recycling = len(self.state['waste_pile']) == 0
             self._flip_waste()
+            if recycling:
+                shaped_reward -= 20
         done = self._check_done()
-        reward = 1 if done else 0
+        reward = (1 if done else 0) + shaped_reward
         return self._get_obs(), reward, done, False, {}
 
     # Observation encoding

--- a/train.py
+++ b/train.py
@@ -2,6 +2,8 @@ import os
 import numpy as np
 import torch
 from gym.vector import SyncVectorEnv
+import time
+from tqdm import trange
 
 from solitaire_env import KlondikeEnv
 from dqn_agent import DQNAgent
@@ -13,12 +15,17 @@ def make_env():
 
 def train(total_steps=10000000, num_envs=32, checkpoint_dir="checkpoints"):
     os.makedirs(checkpoint_dir, exist_ok=True)
+    sample_env = KlondikeEnv()
+    agent = DQNAgent(sample_env.observation_space.shape[0], sample_env.action_space.n)
+    print(
+        f"Starting training: total_steps={total_steps}, num_envs={num_envs}, device={agent.device}"
+    )
+    start_time = time.time()
     env = SyncVectorEnv([make_env for _ in range(num_envs)])
-    agent = DQNAgent(env.single_observation_space.shape[0], env.single_action_space.n)
     state, _ = env.reset()
     wins = np.zeros(num_envs, dtype=int)
 
-    for step in range(1, total_steps + 1):
+    for step in trange(1, total_steps + 1, desc="Training", unit="step"):
         actions = [agent.select_action(s) for s in state]
         next_state, rewards, dones, truncs, _ = env.step(actions)
         done_flags = np.logical_or(dones, truncs)
@@ -26,16 +33,23 @@ def train(total_steps=10000000, num_envs=32, checkpoint_dir="checkpoints"):
             agent.store_transition(state[i], actions[i], rewards[i], next_state[i], done_flags[i])
             if done_flags[i] and rewards[i] > 0:
                 wins[i] += 1
-        agent.update()
+        loss = agent.update()
         agent.step()
+        if loss is not None:
+            print(f"[Step {step}] loss={loss:.4f}   ε={agent.epsilon:.3f}")
         state = next_state
 
         if step % 10000 == 0:
             avg_win = wins.sum() / (num_envs)
-            print(f"Step {step}: avg wins {avg_win}")
             torch_path = os.path.join(checkpoint_dir, f"dqn_{step}.pth")
             torch.save(agent.q_net.state_dict(), torch_path)
+            elapsed = time.time() - start_time
+            print(f"\u2192 Step {step}: avg wins={avg_win:.3f}   elapsed={elapsed/60:.1f}m")
+            print(f"  Saved checkpoint: {torch_path}")
             wins[:] = 0
+
+    total_time = (time.time() - start_time) / 3600
+    print(f"Training complete in {total_time:.1f} hours")
 
 
 if __name__ == "__main__":

--- a/train.py
+++ b/train.py
@@ -1,12 +1,28 @@
 import os
+import time
 import numpy as np
 import torch
 from gym.vector import SyncVectorEnv
-import time
 from tqdm import trange
+from torch.utils.tensorboard import SummaryWriter
+import matplotlib.pyplot as plt
 
 from solitaire_env import KlondikeEnv
 from dqn_agent import DQNAgent
+
+
+def run_evaluation(agent, num_games):
+    eval_env = SyncVectorEnv([make_env for _ in range(num_games)])
+    state, _ = eval_env.reset()
+    wins = 0
+    done_flags = np.zeros(num_games, dtype=bool)
+    while not done_flags.all():
+        actions = [agent.select_action(s, eval=True) for s in state]
+        next_state, rewards, dones, truncs, _ = eval_env.step(actions)
+        wins += rewards.sum()
+        state = next_state
+        done_flags = np.logical_or(dones, truncs)
+    return wins / num_games
 
 
 def make_env():
@@ -15,6 +31,20 @@ def make_env():
 
 def train(total_steps=10000000, num_envs=32, checkpoint_dir="checkpoints"):
     os.makedirs(checkpoint_dir, exist_ok=True)
+    plots_dir = "plots"
+    os.makedirs(plots_dir, exist_ok=True)
+
+    # Logging intervals
+    log_interval = 1000
+    tb_interval = 500
+    plot_interval = 2000
+    eval_interval = 10000
+    num_eval_games = 100
+
+    writer = SummaryWriter(log_dir="runs/solitaire")
+    metrics = {"loss": [], "train_win_rate": [], "eval_win_rate": []}
+    steps = []
+
     sample_env = KlondikeEnv()
     agent = DQNAgent(sample_env.observation_space.shape[0], sample_env.action_space.n)
     print(
@@ -24,8 +54,16 @@ def train(total_steps=10000000, num_envs=32, checkpoint_dir="checkpoints"):
     env = SyncVectorEnv([make_env for _ in range(num_envs)])
     state, _ = env.reset()
     wins = np.zeros(num_envs, dtype=int)
+    recent_win_rate = 0
 
-    for step in trange(1, total_steps + 1, desc="Training", unit="step"):
+    for step in trange(
+        1,
+        total_steps + 1,
+        desc="Training",
+        unit="step",
+        mininterval=5,
+        leave=True,
+    ):
         actions = [agent.select_action(s) for s in state]
         next_state, rewards, dones, truncs, _ = env.step(actions)
         done_flags = np.logical_or(dones, truncs)
@@ -35,9 +73,43 @@ def train(total_steps=10000000, num_envs=32, checkpoint_dir="checkpoints"):
                 wins[i] += 1
         loss = agent.update()
         agent.step()
-        if loss is not None:
-            print(f"[Step {step}] loss={loss:.4f}   ε={agent.epsilon:.3f}")
         state = next_state
+
+        if step % log_interval == 0 and loss is not None:
+            recent_win_rate = wins.sum() / num_envs
+            print(
+                f"[Step {step}] loss={loss:.4f}, ε={agent.epsilon:.2f}, win_rate={recent_win_rate:.3f}"
+            )
+            wins[:] = 0
+
+        if step % tb_interval == 0 and loss is not None:
+            writer.add_scalar("train/loss", loss, step)
+            writer.add_scalar("train/ε", agent.epsilon, step)
+            writer.add_scalar("train/win_rate", recent_win_rate, step)
+
+        if step % eval_interval == 0:
+            old_eps = agent.epsilon
+            agent.epsilon = 0.0
+            eval_win_rate = run_evaluation(agent, num_eval_games)
+            writer.add_scalar("eval/win_rate", eval_win_rate, step)
+            print(f">>> Eval @ {step}: win_rate={eval_win_rate:.3f}")
+            agent.epsilon = old_eps
+
+        if step % plot_interval == 0 and loss is not None:
+            steps.append(step)
+            metrics["loss"].append(loss)
+            metrics["train_win_rate"].append(recent_win_rate)
+            metrics["eval_win_rate"].append(
+                eval_win_rate if "eval_win_rate" in locals() else np.nan
+            )
+            plt.figure()
+            plt.plot(steps, metrics["train_win_rate"], label="Train Win Rate")
+            plt.plot(steps, metrics["eval_win_rate"], label="Eval Win Rate")
+            plt.xlabel("Steps")
+            plt.ylabel("Win Rate")
+            plt.legend()
+            plt.savefig(os.path.join(plots_dir, f"win_rate_{step}.png"))
+            plt.close()
 
         if step % 10000 == 0:
             avg_win = wins.sum() / (num_envs)
@@ -50,6 +122,7 @@ def train(total_steps=10000000, num_envs=32, checkpoint_dir="checkpoints"):
 
     total_time = (time.time() - start_time) / 3600
     print(f"Training complete in {total_time:.1f} hours")
+    writer.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- fix windows path escaping in evaluate_moves
- build template paths with `os.path.join`
- inline `is_valid_column_move` to remove GUI deps
- guard foundation rank lookup against invalid strings

## Testing
- `python -m py_compile solitaire_env.py scripts/utils.py scripts/evaluate_moves.py train.py`
- `python -W default train.py 2>&1 | head -n 5` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_684c6aba642c832a8c4e4dce87286cf5