### PR TITLE
Define max_moves for KlondikeEnv

### DIFF
--- a/solitaire_env.py
+++ b/solitaire_env.py
@@ -57,6 +57,9 @@ class KlondikeEnv(gym.Env):
         self.state = None
         self.face_down_counts = None
         self.no_move_since_recycle = False
+        # Rough upper bound on the number of moves in a single game.
+        # Used by training utilities to cap evaluation length.
+        self.max_moves = 200
 
     # --- Helpers ----------------------------------------------------------
     def _can_play_foundation(self, card):


### PR DESCRIPTION
## Summary
- add `max_moves` attribute to `KlondikeEnv` for evaluation step limit

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'win32gui')*

------
https://chatgpt.com/codex/tasks/task_e_684ceef1cd44832a878964bc356fa290